### PR TITLE
feat(src/default.json5): ignore bun.lockb to work with empty bun.lockb files

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,6 +9,11 @@
 		":prConcurrentLimitNone",
 		"customManagers:biomeVersions"
 	],
+	"bun": {
+		"fileMatch": [
+			"(^|/)bun\\.lock$"
+		]
+	},
 	"labels": [
 		"dependencies",
 		"{{#unless (equals manager 'regex')}}{{manager}}{{/unless}}"

--- a/src/default.json5
+++ b/src/default.json5
@@ -11,6 +11,11 @@
 		":prConcurrentLimitNone",
 		"customManagers:biomeVersions",
 	],
+	bun: {
+		// ignore bun.lockb
+		// an empty bun.lockb is required to Bun detected by Cloudflare Workers/Pages Builds
+		fileMatch: ["(^|/)bun\\.lock$"],
+	},
 	labels: [
 		"dependencies",
 		"{{#unless (equals manager 'regex')}}{{manager}}{{/unless}}",


### PR DESCRIPTION
ignore bun.lockb by bun manager and only update bun.lock

BREAKING CHANGE: bun.lockb files are no more updated
