### PR TITLE
Revert "fix(src/default.json5): set datasourceTemplate for mise tools shorthands (#276)"

### DIFF
--- a/default.json
+++ b/default.json
@@ -30,7 +30,7 @@
 				"(^|/)\\.?mise\\.toml$",
 				"(^|/)\\.?mise/config\\.toml$"
 			],
-			"datasourceTemplate": "github-releases",
+			"datasourceTemplate": "undefined",
 			"matchStrings": [
 				"^['\"]?(?<depName>[^_:\\s]+?)['\"]? *= *['\"](?<currentValue>\\d.+?)['\"]"
 			]
@@ -131,6 +131,7 @@
 			"matchDepNames": [
 				"taplo"
 			],
+			"overrideDatasource": "github-releases",
 			"overridePackageName": "tamasfe/taplo"
 		},
 		{
@@ -140,6 +141,7 @@
 			"matchDepNames": [
 				"biome"
 			],
+			"overrideDatasource": "github-releases",
 			"overridePackageName": "biomejs/biome",
 			"extractVersion": "^cli/v(?<version>.+)"
 		},
@@ -150,6 +152,7 @@
 			"matchDepNames": [
 				"lychee"
 			],
+			"overrideDatasource": "github-releases",
 			"overridePackageName": "lycheeverse/lychee",
 			"extractVersion": "^lychee-v(?<version>.+)"
 		}

--- a/src/default.json5
+++ b/src/default.json5
@@ -34,8 +34,9 @@
 			customType: "regex",
 			description: "Updates mise tools (shorthands)",
 			fileMatch: ["(^|/)\\.?mise\\.toml$", "(^|/)\\.?mise/config\\.toml$"],
-			// if not set or set to undefined, Renovate does not update the version
-			datasourceTemplate: "github-releases",
+			// to avoid renovate config validator error
+			// Renovate throws "Missing datasource!" warnings but still works
+			datasourceTemplate: "undefined",
 			matchStrings: [
 				// test: https://regex101.com/r/8grHta
 				"^['\"]?(?<depName>[^_:\\s]+?)['\"]? *= *['\"](?<currentValue>\\d.+?)['\"]",
@@ -120,18 +121,21 @@
 		{
 			matchManagers: ["custom.regex"],
 			matchDepNames: ["taplo"],
+			overrideDatasource: "github-releases",
 			// cspell:ignore tamasfe
 			overridePackageName: "tamasfe/taplo",
 		},
 		{
 			matchManagers: ["custom.regex"],
 			matchDepNames: ["biome"],
+			overrideDatasource: "github-releases",
 			overridePackageName: "biomejs/biome",
 			extractVersion: "^cli/v(?<version>.+)",
 		},
 		{
 			matchManagers: ["custom.regex"],
 			matchDepNames: ["lychee"],
+			overrideDatasource: "github-releases",
 			// cspell:ignore lycheeverse
 			overridePackageName: "lycheeverse/lychee",
 			extractVersion: "^lychee-v(?<version>.+)",


### PR DESCRIPTION
This reverts commit 26590bc27ac17034f38630c8a7d4a68d3765b76f.
