### PR TITLE
Revert "feat(src/default.json5): support sha256 of mise-action (#835)"

### DIFF
--- a/default.json
+++ b/default.json
@@ -53,7 +53,7 @@
 				"/(^|/)action\\.ya?ml$/"
 			],
 			"fileFormat": "yaml",
-			"datasourceTemplate": "github-release-attachments",
+			"datasourceTemplate": "github-releases",
 			"depNameTemplate": "mise",
 			"packageNameTemplate": "jdx/mise",
 			"matchStrings": [

--- a/default.json
+++ b/default.json
@@ -57,7 +57,7 @@
 			"depNameTemplate": "mise",
 			"packageNameTemplate": "jdx/mise",
 			"matchStrings": [
-				"$.jobs.*.steps[$substringBefore(uses, \"@\") = \"jdx/mise-action\"].with.{ \"currentValue\": version, \"currentDigest\": sha256 }"
+				"$.jobs.*.steps[$substringBefore(uses, \"@\") = \"jdx/mise-action\"].with.version.{ \"currentValue\": $ }"
 			]
 		},
 		{

--- a/src/default.json5
+++ b/src/default.json5
@@ -64,7 +64,7 @@
 			depNameTemplate: "mise",
 			packageNameTemplate: "jdx/mise",
 			matchStrings: [
-				'$.jobs.*.steps[$substringBefore(uses, "@") = "jdx/mise-action"].with.{ "currentValue": version, "currentDigest": sha256 }',
+				'$.jobs.*.steps[$substringBefore(uses, "@") = "jdx/mise-action"].with.version.{ "currentValue": $ }',
 			],
 		},
 		{

--- a/src/default.json5
+++ b/src/default.json5
@@ -60,7 +60,7 @@
 				"/(^|/)action\\.ya?ml$/",
 			],
 			fileFormat: "yaml",
-			datasourceTemplate: "github-release-attachments",
+			datasourceTemplate: "github-releases",
 			depNameTemplate: "mise",
 			packageNameTemplate: "jdx/mise",
 			matchStrings: [


### PR DESCRIPTION
This reverts commit a5472bd58c9995106f607758901e5ada37a7a077.

I need to use the regex custom manager due to the bug of the jsonata manager, but I don't want to.
https://github.com/renovatebot/renovate/discussions/34567