### PR TITLE
feat(src/default.json5): support hk

### DIFF
--- a/default.json
+++ b/default.json
@@ -34,6 +34,21 @@
 			]
 		},
 		{
+			"customType": "regex",
+			"description": "Updates hk Pkl package imports",
+			"managerFilePatterns": [
+				"/(^|/)hk\\.pkl$/"
+			],
+			"datasourceTemplate": "github-releases",
+			"depNameTemplate": "hk",
+			"packageNameTemplate": "jdx/hk",
+			"extractVersionTemplate": "^v(?<version>.+)$",
+			"matchStrings": [
+				"package://github\\.com/jdx/hk/releases/download/v(?<currentValue>[^/]+)/hk@[^#]+#"
+			],
+			"autoReplaceStringTemplate": "package://github.com/jdx/hk/releases/download/v{{{newValue}}}/hk@{{{newValue}}}#"
+		},
+		{
 			"customType": "jsonata",
 			"description": "Updates min_version in mise config",
 			"managerFilePatterns": [
@@ -167,6 +182,17 @@
 				"custom.jsonata"
 			],
 			"matchDepNames": [
+				"hk"
+			],
+			"overrideDatasource": "github-releases",
+			"overridePackageName": "jdx/hk",
+			"extractVersion": "^v(?<version>.+)"
+		},
+		{
+			"matchManagers": [
+				"custom.jsonata"
+			],
+			"matchDepNames": [
 				"ghalint"
 			],
 			"overrideDatasource": "github-releases",
@@ -225,6 +251,12 @@
 				"@biomejs/biome"
 			],
 			"groupName": "biome"
+		},
+		{
+			"matchDepNames": [
+				"hk"
+			],
+			"groupName": "hk"
 		}
 	]
 }

--- a/src/default.json5
+++ b/src/default.json5
@@ -37,6 +37,19 @@
 			],
 		},
 		{
+			customType: "regex",
+			description: "Updates hk Pkl package imports",
+			managerFilePatterns: ["/(^|/)hk\\.pkl$/"],
+			datasourceTemplate: "github-releases",
+			depNameTemplate: "hk",
+			packageNameTemplate: "jdx/hk",
+			extractVersionTemplate: "^v(?<version>.+)$",
+			matchStrings: [
+				"package://github\\.com/jdx/hk/releases/download/v(?<currentValue>[^/]+)/hk@[^#]+#",
+			],
+			autoReplaceStringTemplate: "package://github.com/jdx/hk/releases/download/v{{{newValue}}}/hk@{{{newValue}}}#",
+		},
+		{
 			customType: "jsonata",
 			description: "Updates min_version in mise config",
 			managerFilePatterns: [
@@ -183,6 +196,13 @@
 		},
 		{
 			matchManagers: ["custom.jsonata"],
+			matchDepNames: ["hk"],
+			overrideDatasource: "github-releases",
+			overridePackageName: "jdx/hk",
+			extractVersion: "^v(?<version>.+)",
+		},
+		{
+			matchManagers: ["custom.jsonata"],
 			matchDepNames: ["ghalint"],
 			overrideDatasource: "github-releases",
 			overridePackageName: "suzuki-shunsuke/ghalint",
@@ -217,6 +237,10 @@
 		{
 			matchDepNames: ["biome", "@biomejs/biome"],
 			groupName: "biome",
+		},
+		{
+			matchDepNames: ["hk"],
+			groupName: "hk",
 		},
 	],
 }


### PR DESCRIPTION
## Summary
- add a regex custom manager for hk.pkl package imports
- map mise hk tool updates to jdx/hk GitHub releases
- group hk.pkl and mise.toml hk updates together

## Verification
- mise task run build
- mise task run test
- renovate-config-validator --strict default.json
- renovate-config-validator --strict src/default.json5
- git diff --check