### PR TITLE
feat(src/default.json5): add hk and hk-config preset updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -64,21 +64,6 @@
 			"autoReplaceStringTemplate": "https://raw.githubusercontent.com/risu729/hk-config/v{{{newValue}}}/"
 		},
 		{
-			"customType": "regex",
-			"description": "Updates risu729 hk-config dogfood version",
-			"managerFilePatterns": [
-				"/(^|/)\\.preset-version$/"
-			],
-			"datasourceTemplate": "github-releases",
-			"depNameTemplate": "hk-config",
-			"packageNameTemplate": "risu729/hk-config",
-			"extractVersionTemplate": "^v(?<version>.+)$",
-			"matchStrings": [
-				"^v(?<currentValue>.+)$"
-			],
-			"autoReplaceStringTemplate": "v{{{newValue}}}"
-		},
-		{
 			"customType": "jsonata",
 			"description": "Updates min_version in mise config",
 			"managerFilePatterns": [

--- a/default.json
+++ b/default.json
@@ -49,6 +49,36 @@
 			"autoReplaceStringTemplate": "package://github.com/jdx/hk/releases/download/v{{{newValue}}}/hk@{{{newValue}}}#"
 		},
 		{
+			"customType": "regex",
+			"description": "Updates risu729 hk-config preset imports in hk.pkl",
+			"managerFilePatterns": [
+				"/(^|/)hk\\.pkl$/"
+			],
+			"datasourceTemplate": "github-releases",
+			"depNameTemplate": "hk-config",
+			"packageNameTemplate": "risu729/hk-config",
+			"extractVersionTemplate": "^v(?<version>.+)$",
+			"matchStrings": [
+				"https://raw\\.githubusercontent\\.com/risu729/hk-config/v(?<currentValue>[^/]+)/"
+			],
+			"autoReplaceStringTemplate": "https://raw.githubusercontent.com/risu729/hk-config/v{{{newValue}}}/"
+		},
+		{
+			"customType": "regex",
+			"description": "Updates risu729 hk-config dogfood version",
+			"managerFilePatterns": [
+				"/(^|/)\\.preset-version$/"
+			],
+			"datasourceTemplate": "github-releases",
+			"depNameTemplate": "hk-config",
+			"packageNameTemplate": "risu729/hk-config",
+			"extractVersionTemplate": "^v(?<version>.+)$",
+			"matchStrings": [
+				"^v(?<currentValue>.+)$"
+			],
+			"autoReplaceStringTemplate": "v{{{newValue}}}"
+		},
+		{
 			"customType": "jsonata",
 			"description": "Updates min_version in mise config",
 			"managerFilePatterns": [
@@ -258,6 +288,12 @@
 				"hk"
 			],
 			"groupName": "hk"
+		},
+		{
+			"matchDepNames": [
+				"hk-config"
+			],
+			"groupName": "hk-config"
 		}
 	]
 }

--- a/src/default.json5
+++ b/src/default.json5
@@ -50,6 +50,30 @@
 			autoReplaceStringTemplate: "package://github.com/jdx/hk/releases/download/v{{{newValue}}}/hk@{{{newValue}}}#",
 		},
 		{
+			customType: "regex",
+			description: "Updates risu729 hk-config preset imports in hk.pkl",
+			managerFilePatterns: ["/(^|/)hk\\.pkl$/"],
+			datasourceTemplate: "github-releases",
+			depNameTemplate: "hk-config",
+			packageNameTemplate: "risu729/hk-config",
+			extractVersionTemplate: "^v(?<version>.+)$",
+			matchStrings: [
+				"https://raw\\.githubusercontent\\.com/risu729/hk-config/v(?<currentValue>[^/]+)/",
+			],
+			autoReplaceStringTemplate: "https://raw.githubusercontent.com/risu729/hk-config/v{{{newValue}}}/",
+		},
+		{
+			customType: "regex",
+			description: "Updates risu729 hk-config dogfood version",
+			managerFilePatterns: ["/(^|/)\\.preset-version$/"],
+			datasourceTemplate: "github-releases",
+			depNameTemplate: "hk-config",
+			packageNameTemplate: "risu729/hk-config",
+			extractVersionTemplate: "^v(?<version>.+)$",
+			matchStrings: ["^v(?<currentValue>.+)$"],
+			autoReplaceStringTemplate: "v{{{newValue}}}",
+		},
+		{
 			customType: "jsonata",
 			description: "Updates min_version in mise config",
 			managerFilePatterns: [
@@ -241,6 +265,10 @@
 		{
 			matchDepNames: ["hk"],
 			groupName: "hk",
+		},
+		{
+			matchDepNames: ["hk-config"],
+			groupName: "hk-config",
 		},
 	],
 }

--- a/src/default.json5
+++ b/src/default.json5
@@ -63,17 +63,6 @@
 			autoReplaceStringTemplate: "https://raw.githubusercontent.com/risu729/hk-config/v{{{newValue}}}/",
 		},
 		{
-			customType: "regex",
-			description: "Updates risu729 hk-config dogfood version",
-			managerFilePatterns: ["/(^|/)\\.preset-version$/"],
-			datasourceTemplate: "github-releases",
-			depNameTemplate: "hk-config",
-			packageNameTemplate: "risu729/hk-config",
-			extractVersionTemplate: "^v(?<version>.+)$",
-			matchStrings: ["^v(?<currentValue>.+)$"],
-			autoReplaceStringTemplate: "v{{{newValue}}}",
-		},
-		{
 			customType: "jsonata",
 			description: "Updates min_version in mise config",
 			managerFilePatterns: [


### PR DESCRIPTION
## Summary
- Add a regex manager for `jdx/hk` Pkl package imports in `hk.pkl`
- Add regex managers for `risu729/hk-config` raw GitHub preset URLs in `hk.pkl` and dogfood versions in `.preset-version`
- Group `hk` and `hk-config` dependency updates separately

## Test plan
- [ ] `mise run build` regenerates `default.json`
- [ ] `mise run check:renovate` passes
- [ ] Renovate opens PRs bumping `package://github.com/jdx/hk/...` imports
- [ ] Renovate opens PRs bumping `https://raw.githubusercontent.com/risu729/hk-config/v.../` imports


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Introduce Renovate configuration for managing hk and hk-config presets and their related dependency updates.

New Features:
- Add regex-based managers for jdx/hk Pkl package imports in hk.pkl.
- Add regex-based managers for risu729/hk-config raw GitHub preset URLs, including dogfood versions, in configuration files.

Enhancements:
- Group hk and hk-config dependency updates into separate update groups in the Renovate configuration.