### PR TITLE
chore(release): disable semantic-release success pr comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write # for GitHub Release
-      issues: write # for commenting on issues
-      pull-requests: write # for commenting on pull requests
 
     steps:
       - name: Checkout

--- a/release.config.js
+++ b/release.config.js
@@ -11,6 +11,7 @@ const config = {
 			"@semantic-release/github",
 			{
 				successComment: false,
+				failCommentCondition: false,
 			},
 		],
 	],

--- a/release.config.js
+++ b/release.config.js
@@ -10,8 +10,8 @@ const config = {
 		[
 			"@semantic-release/github",
 			{
-				successComment: false,
 				failCommentCondition: false,
+				successComment: false,
 			},
 		],
 	],

--- a/release.config.js
+++ b/release.config.js
@@ -7,7 +7,12 @@ const config = {
 	plugins: [
 		"@semantic-release/commit-analyzer",
 		"@semantic-release/release-notes-generator",
-		"@semantic-release/github",
+		[
+			"@semantic-release/github",
+			{
+				successComment: false,
+			},
+		],
 	],
 	// oxlint-disable-next-line eslint/no-template-curly-in-string
 	tagFormat: "${version}",


### PR DESCRIPTION
## Summary
- Disable `@semantic-release/github` success comments on merged PRs after release

## Test plan
- [ ] Next release on `main` does not comment "Released in version X" on PRs


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Build:
- Update semantic-release GitHub plugin configuration to disable post-release success comments on pull requests.