### PR TITLE
fix: guard mise tools JSONata query

### DIFF
--- a/default.json
+++ b/default.json
@@ -30,7 +30,7 @@
 			"fileFormat": "toml",
 			"datasourceTemplate": "undefined",
 			"matchStrings": [
-				"$each($.tools, function($v, $k) { $contains($k, \":\") ? undefined : { \"depName\": $k, \"currentValue\": $type($v) = \"string\" ? $v : $v.version } })"
+				"$exists($.tools) ? $each($.tools, function($v, $k) { $contains($k, \":\") ? undefined : { \"depName\": $k, \"currentValue\": $type($v) = \"string\" ? $v : $v.version } }) : []"
 			]
 		},
 		{

--- a/src/default.json5
+++ b/src/default.json5
@@ -33,7 +33,7 @@
 			// Renovate throws "Missing datasource!" warnings but still works
 			datasourceTemplate: "undefined",
 			matchStrings: [
-				'$each($.tools, function($v, $k) { $contains($k, ":") ? undefined : { "depName": $k, "currentValue": $type($v) = "string" ? $v : $v.version } })',
+				'$exists($.tools) ? $each($.tools, function($v, $k) { $contains($k, ":") ? undefined : { "depName": $k, "currentValue": $type($v) = "string" ? $v : $v.version } }) : []',
 			],
 		},
 		{

--- a/test/mise.test.ts
+++ b/test/mise.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+
+import jsonata from "jsonata";
+
+// oxlint-disable-next-line import/no-relative-parent-imports
+import config from "../default.json" with { type: "json" };
+
+const expression = config.customManagers
+	.find((manager) => manager.description === "Updates mise tools (shorthands)")
+	?.matchStrings.at(0);
+
+test("mise tools JSONata expression ignores configs without tools", async () => {
+	expect(expression).toBeDefined();
+
+	const result = await jsonata(expression!).evaluate({
+		tasks: {
+			test: {
+				run: "bun test",
+			},
+		},
+	});
+	expect(result).toEqual([]);
+});
+
+test("mise tools JSONata expression extracts shorthand tools", async () => {
+	expect(expression).toBeDefined();
+
+	const result = await jsonata(expression!).evaluate({
+		tools: {
+			bun: "1.3.14",
+			hk: {
+				version: "1.48.0",
+			},
+			"npm:typescript": "6.0.3",
+		},
+	});
+	expect(result).toEqual([
+		{
+			currentValue: "1.3.14",
+			depName: "bun",
+		},
+		{
+			currentValue: "1.48.0",
+			depName: "hk",
+		},
+	]);
+});

--- a/test/wrangler.test.ts
+++ b/test/wrangler.test.ts
@@ -6,6 +6,49 @@ import jsonata from "jsonata";
 import config from "../default.json" with { type: "json" };
 import response from "./fixtures/npm-registry-miniflare.json" with { type: "json" };
 
+test("mise tools JSONata expression ignores configs without tools", async () => {
+	const expression = config.customManagers
+		.find((manager) => manager.description === "Updates mise tools (shorthands)")
+		?.matchStrings.at(0);
+	expect(expression).toBeDefined();
+
+	const result = await jsonata(expression!).evaluate({
+		tasks: {
+			test: {
+				run: "bun test",
+			},
+		},
+	});
+	expect(result).toEqual([]);
+});
+
+test("mise tools JSONata expression extracts shorthand tools", async () => {
+	const expression = config.customManagers
+		.find((manager) => manager.description === "Updates mise tools (shorthands)")
+		?.matchStrings.at(0);
+	expect(expression).toBeDefined();
+
+	const result = await jsonata(expression!).evaluate({
+		tools: {
+			bun: "1.3.14",
+			hk: {
+				version: "1.48.0",
+			},
+			"npm:typescript": "6.0.3",
+		},
+	});
+	expect(result).toEqual([
+		{
+			currentValue: "1.3.14",
+			depName: "bun",
+		},
+		{
+			currentValue: "1.48.0",
+			depName: "hk",
+		},
+	]);
+});
+
 test("wrangler-compatibility-date JSONata expression", async () => {
 	const expression =
 		config.customDatasources["wrangler-compatibility-date"].transformTemplates.at(0);

--- a/test/wrangler.test.ts
+++ b/test/wrangler.test.ts
@@ -6,49 +6,6 @@ import jsonata from "jsonata";
 import config from "../default.json" with { type: "json" };
 import response from "./fixtures/npm-registry-miniflare.json" with { type: "json" };
 
-test("mise tools JSONata expression ignores configs without tools", async () => {
-	const expression = config.customManagers
-		.find((manager) => manager.description === "Updates mise tools (shorthands)")
-		?.matchStrings.at(0);
-	expect(expression).toBeDefined();
-
-	const result = await jsonata(expression!).evaluate({
-		tasks: {
-			test: {
-				run: "bun test",
-			},
-		},
-	});
-	expect(result).toEqual([]);
-});
-
-test("mise tools JSONata expression extracts shorthand tools", async () => {
-	const expression = config.customManagers
-		.find((manager) => manager.description === "Updates mise tools (shorthands)")
-		?.matchStrings.at(0);
-	expect(expression).toBeDefined();
-
-	const result = await jsonata(expression!).evaluate({
-		tools: {
-			bun: "1.3.14",
-			hk: {
-				version: "1.48.0",
-			},
-			"npm:typescript": "6.0.3",
-		},
-	});
-	expect(result).toEqual([
-		{
-			currentValue: "1.3.14",
-			depName: "bun",
-		},
-		{
-			currentValue: "1.48.0",
-			depName: "hk",
-		},
-	]);
-});
-
 test("wrangler-compatibility-date JSONata expression", async () => {
 	const expression =
 		config.customDatasources["wrangler-compatibility-date"].transformTemplates.at(0);


### PR DESCRIPTION
## Summary

- Guard the mise shorthand-tools JSONata query when a matched mise config has no `tools` table.
- Regenerate `default.json` from `src/default.json5`.
- Add tests for package-level mise configs without tools and for shorthand tool extraction.

## Root cause

The preset matched all mise config files but evaluated `$each($.tools, ...)` unconditionally. Repositories with package-level mise files containing only tasks caused JSONata to throw `Cannot convert undefined or null to object` on Renovate versions that did not catch evaluation errors.

This is fixable in the preset: JSONata supports guarding the missing property with `$exists($.tools) ? ... : []`.

## Validation

- `mise run test`
- `mise run check --lint`

## Summary by Sourcery

Guard the JSONata-based mise tools matcher against configs without a tools table and regenerate the default preset configuration.

Bug Fixes:
- Prevent JSONata evaluation errors when preset processes mise configs that define tasks but no tools table.

Tests:
- Add tests verifying the mise tools JSONata expression ignores configs without tools and correctly extracts shorthand tools.

Chores:
- Regenerate default.json from the JSON5 source configuration.