### PR TITLE
fix: update mise versions in composite actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -90,7 +90,7 @@
 			"depNameTemplate": "mise",
 			"packageNameTemplate": "jdx/mise",
 			"matchStrings": [
-				"$.jobs.*.steps[$substringBefore(uses, \"@\") = \"jdx/mise-action\"].with.version.{ \"currentValue\": $ }"
+				"($append($.jobs.*.steps, $.runs.steps))[$substringBefore(uses, \"@\") = \"jdx/mise-action\"].with.version.{ \"currentValue\": $ }"
 			]
 		},
 		{

--- a/src/default.json5
+++ b/src/default.json5
@@ -89,7 +89,7 @@
 			depNameTemplate: "mise",
 			packageNameTemplate: "jdx/mise",
 			matchStrings: [
-				'$.jobs.*.steps[$substringBefore(uses, "@") = "jdx/mise-action"].with.version.{ "currentValue": $ }',
+				'($append($.jobs.*.steps, $.runs.steps))[$substringBefore(uses, "@") = "jdx/mise-action"].with.version.{ "currentValue": $ }',
 			],
 		},
 		{

--- a/test/mise.test.ts
+++ b/test/mise.test.ts
@@ -9,6 +9,10 @@ const expression = config.customManagers
 	.find((manager) => manager.description === "Updates mise tools (shorthands)")
 	?.matchStrings.at(0);
 
+const githubActionsExpression = config.customManagers
+	.find((manager) => manager.description === "Updates mise versions in GitHub Actions")
+	?.matchStrings.at(0);
+
 test("mise tools JSONata expression ignores configs without tools", async () => {
 	expect(expression).toBeDefined();
 
@@ -44,4 +48,25 @@ test("mise tools JSONata expression extracts shorthand tools", async () => {
 			depName: "hk",
 		},
 	]);
+});
+
+test("mise GitHub Actions JSONata expression extracts composite action versions", async () => {
+	expect(githubActionsExpression).toBeDefined();
+
+	const result = await jsonata(githubActionsExpression!).evaluate({
+		runs: {
+			steps: [
+				{
+					uses: "jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d",
+					with: {
+						version: "2026.6.13",
+					},
+				},
+			],
+			using: "composite",
+		},
+	});
+	expect(result).toEqual({
+		currentValue: "2026.6.13",
+	});
 });


### PR DESCRIPTION
## Summary

- extend the mise GitHub Actions custom manager to include composite action `runs.steps`
- keep the generated `default.json` in sync with `src/default.json5`
- add a regression test for a composite action using `jdx/mise-action` with a pinned `version`

## Root Cause

Mikoto PR #86 updates `mise.toml` to require `mise 2026.7.0`, but Renovate only updated workflow job steps. The shared composite action `.github/actions/relay-deploy/action.yml` still installed `2026.6.13`, so `mise install --locked` failed with the required-version error.

## Validation

- `bun test`
- `mise run check --lint`

## Summary by Sourcery

Update the mise custom manager to handle versions used in GitHub composite actions and keep default configuration files in sync.

New Features:
- Support updating mise versions referenced in GitHub composite actions via the custom manager.

Enhancements:
- Synchronize the generated default.json with src/default.json5 to ensure consistent default configuration.

Tests:
- Add a regression test verifying version extraction from a composite action using jdx/mise-action with a pinned version.