### PR TITLE
ci: trim redundant token env

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -36,8 +36,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run autofix
         run: mise run check --continue-on-error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run check
         run: mise run check --lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,6 @@ jobs:
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           version: 2026.7.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Release
         env:


### PR DESCRIPTION
## Summary

- Remove redundant `GITHUB_TOKEN` env entries from `jdx/mise-action` install steps.
- Keep `GITHUB_TOKEN` on the check and release execution steps that actually use it.

## Related

- Same cleanup in mikoto: https://github.com/risu729/mikoto/pull/67

## Validation

- `mise run check --lint`

## Summary by Sourcery

CI:
- Remove unnecessary GITHUB_TOKEN env entries from jdx/mise-action steps in autofix, CI, and release workflows, keeping token usage only where required.