### PR TITLE
fix(mise): remove redundant shorthand manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,19 +18,6 @@
 	],
 	"customManagers": [
 		{
-			"customType": "jsonata",
-			"description": "Updates mise tools (shorthands)",
-			"managerFilePatterns": [
-				"/(^|/)\\.?mise\\.toml$/",
-				"/(^|/)\\.?mise/config\\.toml$/"
-			],
-			"fileFormat": "toml",
-			"datasourceTemplate": "undefined",
-			"matchStrings": [
-				"$exists($.tools) ? $each($.tools, function($v, $k) { $contains($k, \":\") ? undefined : { \"depName\": $k, \"currentValue\": $type($v) = \"string\" ? $v : $v.version } }) : []"
-			]
-		},
-		{
 			"customType": "regex",
 			"description": "Updates hk Pkl package imports",
 			"managerFilePatterns": [
@@ -166,97 +153,6 @@
 			"addLabels": [
 				"mise"
 			]
-		},
-		{
-			"matchManagers": [
-				"custom.jsonata"
-			],
-			"matchDepNames": [
-				"cargo-binstall",
-				"cargo-dist",
-				"release-plz",
-				"pitchfork"
-			],
-			"overrideDatasource": "crate"
-		},
-		{
-			"matchManagers": [
-				"custom.jsonata"
-			],
-			"matchDepNames": [
-				"biome"
-			],
-			"overrideDatasource": "github-releases",
-			"overridePackageName": "biomejs/biome",
-			"extractVersion": "^@biomejs/biome@(?<version>.+)"
-		},
-		{
-			"matchManagers": [
-				"custom.jsonata"
-			],
-			"matchDepNames": [
-				"hk"
-			],
-			"overrideDatasource": "github-releases",
-			"overridePackageName": "jdx/hk",
-			"extractVersion": "^v(?<version>.+)"
-		},
-		{
-			"matchManagers": [
-				"custom.jsonata"
-			],
-			"matchDepNames": [
-				"ghalint"
-			],
-			"overrideDatasource": "github-releases",
-			"overridePackageName": "suzuki-shunsuke/ghalint",
-			"extractVersion": "^v(?<version>.+)"
-		},
-		{
-			"matchManagers": [
-				"custom.jsonata"
-			],
-			"matchDepNames": [
-				"pinact"
-			],
-			"overrideDatasource": "github-releases",
-			"overridePackageName": "suzuki-shunsuke/pinact",
-			"extractVersion": "^v(?<version>.+)"
-		},
-		{
-			"matchManagers": [
-				"custom.jsonata"
-			],
-			"matchDepNames": [
-				"jc"
-			],
-			"overrideDatasource": "github-releases",
-			"overridePackageName": "kellyjonbrazil/jc",
-			"extractVersion": "^v(?<version>.+)"
-		},
-		{
-			"matchManagers": [
-				"custom.jsonata"
-			],
-			"matchDepNames": [
-				"powershell"
-			],
-			"overrideDatasource": "github-releases",
-			"overridePackageName": "PowerShell/PowerShell",
-			"extractVersion": "^v(?<version>.+)"
-		},
-		{
-			"matchManagers": [
-				"custom.jsonata"
-			],
-			"matchDepNames": [
-				"cspell",
-				"json5",
-				"prettier",
-				"oxlint",
-				"oxfmt"
-			],
-			"overrideDatasource": "npm"
 		},
 		{
 			"matchDepNames": [

--- a/src/default.json5
+++ b/src/default.json5
@@ -17,24 +17,6 @@
 	],
 	// ref: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
 	customManagers: [
-		// renovate does not support tools not listed
-		// ref: https://docs.renovatebot.com/modules/manager/mise/#additional-information
-		{
-			customType: "jsonata",
-			description: "Updates mise tools (shorthands)",
-			managerFilePatterns: [
-				// ref: https://docs.renovatebot.com/modules/manager/mise/#file-matching
-				"/(^|/)\\.?mise\\.toml$/",
-				"/(^|/)\\.?mise/config\\.toml$/",
-			],
-			fileFormat: "toml",
-			// to avoid renovate config validator error
-			// Renovate throws "Missing datasource!" warnings but still works
-			datasourceTemplate: "undefined",
-			matchStrings: [
-				'$exists($.tools) ? $each($.tools, function($v, $k) { $contains($k, ":") ? undefined : { "depName": $k, "currentValue": $type($v) = "string" ? $v : $v.version } }) : []',
-			],
-		},
 		{
 			customType: "regex",
 			description: "Updates hk Pkl package imports",
@@ -192,59 +174,6 @@
 		{
 			matchFileNames: ["mise.toml"],
 			addLabels: ["mise"],
-		},
-		// mise tools
-		{
-			matchManagers: ["custom.jsonata"],
-			matchDepNames: ["cargo-binstall", "cargo-dist", "release-plz", "pitchfork"],
-			overrideDatasource: "crate",
-		},
-		{
-			matchManagers: ["custom.jsonata"],
-			matchDepNames: ["biome"],
-			overrideDatasource: "github-releases",
-			overridePackageName: "biomejs/biome",
-			extractVersion: "^@biomejs/biome@(?<version>.+)",
-		},
-		{
-			matchManagers: ["custom.jsonata"],
-			matchDepNames: ["hk"],
-			overrideDatasource: "github-releases",
-			overridePackageName: "jdx/hk",
-			extractVersion: "^v(?<version>.+)",
-		},
-		{
-			matchManagers: ["custom.jsonata"],
-			matchDepNames: ["ghalint"],
-			overrideDatasource: "github-releases",
-			overridePackageName: "suzuki-shunsuke/ghalint",
-			extractVersion: "^v(?<version>.+)",
-		},
-		{
-			matchManagers: ["custom.jsonata"],
-			matchDepNames: ["pinact"],
-			overrideDatasource: "github-releases",
-			overridePackageName: "suzuki-shunsuke/pinact",
-			extractVersion: "^v(?<version>.+)",
-		},
-		{
-			matchManagers: ["custom.jsonata"],
-			matchDepNames: ["jc"],
-			overrideDatasource: "github-releases",
-			overridePackageName: "kellyjonbrazil/jc",
-			extractVersion: "^v(?<version>.+)",
-		},
-		{
-			matchManagers: ["custom.jsonata"],
-			matchDepNames: ["powershell"],
-			overrideDatasource: "github-releases",
-			overridePackageName: "PowerShell/PowerShell",
-			extractVersion: "^v(?<version>.+)",
-		},
-		{
-			matchManagers: ["custom.jsonata"],
-			matchDepNames: ["cspell", "json5", "prettier", "oxlint", "oxfmt"],
-			overrideDatasource: "npm",
 		},
 		{
 			matchDepNames: ["biome", "@biomejs/biome"],

--- a/test/mise.test.ts
+++ b/test/mise.test.ts
@@ -5,50 +5,9 @@ import jsonata from "jsonata";
 // oxlint-disable-next-line import/no-relative-parent-imports
 import config from "../default.json" with { type: "json" };
 
-const expression = config.customManagers
-	.find((manager) => manager.description === "Updates mise tools (shorthands)")
-	?.matchStrings.at(0);
-
 const githubActionsExpression = config.customManagers
 	.find((manager) => manager.description === "Updates mise versions in GitHub Actions")
 	?.matchStrings.at(0);
-
-test("mise tools JSONata expression ignores configs without tools", async () => {
-	expect(expression).toBeDefined();
-
-	const result = await jsonata(expression!).evaluate({
-		tasks: {
-			test: {
-				run: "bun test",
-			},
-		},
-	});
-	expect(result).toEqual([]);
-});
-
-test("mise tools JSONata expression extracts shorthand tools", async () => {
-	expect(expression).toBeDefined();
-
-	const result = await jsonata(expression!).evaluate({
-		tools: {
-			bun: "1.3.14",
-			hk: {
-				version: "1.48.0",
-			},
-			"npm:typescript": "6.0.3",
-		},
-	});
-	expect(result).toEqual([
-		{
-			currentValue: "1.3.14",
-			depName: "bun",
-		},
-		{
-			currentValue: "1.48.0",
-			depName: "hk",
-		},
-	]);
-});
 
 test("mise GitHub Actions JSONata expression extracts composite action versions", async () => {
 	expect(githubActionsExpression).toBeDefined();


### PR DESCRIPTION
## Summary

- remove the custom JSONata manager for unqualified mise tool names
- remove datasource and package overrides that only supported that manager
- remove the obsolete shorthand-manager tests
- regenerate `default.json`

## Why

Renovate's native mise manager now resolves both shorthand and qualified tool entries. Keeping the custom manager detects shorthand tools twice and can produce duplicate lockfile commands such as `mise lock oxfmt oxfmt`, which caused `mise.lock` artifact warnings in downstream repositories.

Other JSONata managers remain in place for mise `min_version`, mise-action versions, Wrangler compatibility dates, and cargo-dist configuration.

## Validation

- `mise run check --lint`
- `mise run test`
- `git diff --check`

## Summary by Sourcery

Remove support for the custom shorthand mise tools manager now that Renovate’s native mise manager handles both shorthand and qualified tool entries.

Bug Fixes:
- Prevent duplicate shorthand mise tool detection that could lead to repeated lockfile commands and downstream artifact warnings.

Enhancements:
- Clean up configuration by dropping obsolete datasource and package overrides tied to the removed shorthand manager and regenerating the default configuration file.

Tests:
- Remove now-obsolete tests for the shorthand mise tools JSONata manager while retaining tests for other mise-related managers.