### PR TITLE
feat: group TypeScript updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -172,6 +172,13 @@
 				"hk-config"
 			],
 			"groupName": "hk-config"
+		},
+		{
+			"matchDepNames": [
+				"typescript",
+				"npm:typescript"
+			],
+			"groupName": "typescript"
 		}
 	]
 }

--- a/src/default.json5
+++ b/src/default.json5
@@ -187,5 +187,9 @@
 			matchDepNames: ["hk-config"],
 			groupName: "hk-config",
 		},
+		{
+			matchDepNames: ["typescript", "npm:typescript"],
+			groupName: "typescript",
+		},
 	],
 }


### PR DESCRIPTION
## Summary

- group the npm `typescript` dependency with the mise `npm:typescript` tool
- keep both TypeScript version declarations in a single Renovate PR

## Why

[risu729/tsconfigs#794](https://github.com/risu729/tsconfigs/pull/794) updates the npm dependency separately while `mise.toml` still pins `npm:typescript` to the previous version. Matching both dependency names under one group keeps these coupled declarations synchronized.

## Validation

- `mise run build`
- `mise run test`
- `mise run check`
- `renovate-config-validator --strict`
- `renovate-config-validator --strict default.json`
- `renovate-config-validator --strict src/default.json5`
- `git diff --check`
